### PR TITLE
Disabled Matomo script for debugging

### DIFF
--- a/naturapeute/templates/base.html
+++ b/naturapeute/templates/base.html
@@ -56,7 +56,7 @@
     </div>
   </footer>
 
-  <!-- Matomo -->
+  <!-- Matomo --
   <script type="text/javascript">
     var _paq = window._paq || [];
     /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -70,5 +70,5 @@
       g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
     })();
   </script>
-  <!-- End Matomo Code -->
+   End Matomo Code -->
 </body>


### PR DESCRIPTION
This PR disables the Matomo script in base.html to restore the homepage functionality and allows further debugging 