### PR TITLE
Fix: center map on Switzerland and improve markers bounds handling

### DIFF
--- a/naturapeute/static/js/utils.js
+++ b/naturapeute/static/js/utils.js
@@ -1,14 +1,24 @@
-function initMap(elem, latlng, zoom) {
-  const map = L.map(elem).setView(latlng, zoom)
+const SWITZERLAND_CENTER = [46.8182, 8.2275]; 
+const SWITZERLAND_BOUNDS = [[45.818, 5.000], [47.808, 10.000]]; 
+const DEFAULT_ZOOM = 8;
 
-  L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
+function initMap(elem) {
+    const map = L.map(elem, {
+    center: SWITZERLAND_CENTER,
+    zoom: DEFAULT_ZOOM,
+    maxBounds: SWITZERLAND_BOUNDS,
+    minZoom: 7,
+    maxZoom: 18
+  });
+
+    L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
     attribution: '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>',
     tileSize: 512,
     maxZoom: 18,
-    id: 'mapbox.streets',
-    zoomOffset: -1,
     id: 'mapbox/streets-v11',
+    zoomOffset: -1,
     accessToken: 'pk.eyJ1IjoidGVycmFwZXV0ZXMiLCJhIjoiY2p0N3IxZjRhMDB5bDQ1cW52Z2s2MnVnNCJ9.Ism1OhdYA3qPFom2htkx8w'
-  }).addTo(map)
-  return map
+  }).addTo(map);
+
+  return map;
 }

--- a/naturapeute/templates/therapists.html
+++ b/naturapeute/templates/therapists.html
@@ -226,8 +226,15 @@
     return marker
   })
   const markersGroup = L.featureGroup(markers)
-  map.fitBounds(markersGroup.getBounds())
   markersGroup.addTo(map)
+
+  if (markers.length > 0) {
+  const bounds = markersGroup.getBounds();
+  map.fitBounds(bounds, {
+    padding: [50, 50],
+    maxZoom: 12  // Limita lo zoom massimo quando si fa il fit
+  });
+}
 </script>
 {% endif %}
 


### PR DESCRIPTION
This PR enhances map initialization and marker handling by:

    Setting fixed boundaries for Switzerland
    Adding a minimum zoom level to prevent excessive zooming out
    Improving marker bounds adjustment with padding and maximum zoom
    Ensuring the map always opens centered on Switzerland
    Preventing navigation too far outside Swiss borders
[modifications mappe therapeutes.odt](https://github.com/user-attachments/files/18202761/modifications.mappe.therapeutes.odt)


These changes address the issue where the map could open centered on incorrect locations when therapists are located outside Switzerland.