### PR TITLE
Leaflet map only

### DIFF
--- a/naturapeute/static/js/utils.js
+++ b/naturapeute/static/js/utils.js
@@ -1,14 +1,24 @@
-function initMap(elem, latlng, zoom) {
-  const map = L.map(elem).setView(latlng, zoom)
+const SWITZERLAND_CENTER = [46.8182, 8.2275]; 
+const SWITZERLAND_BOUNDS = [[45.818, 5.000], [47.808, 10.000]]; 
+const DEFAULT_ZOOM = 8;
 
-  L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
+function initMap(elem) {
+    const map = L.map(elem, {
+    center: SWITZERLAND_CENTER,
+    zoom: DEFAULT_ZOOM,
+    maxBounds: SWITZERLAND_BOUNDS,
+    minZoom: 7,
+    maxZoom: 18
+  });
+
+    L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
     attribution: '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>',
     tileSize: 512,
     maxZoom: 18,
-    id: 'mapbox.streets',
-    zoomOffset: -1,
     id: 'mapbox/streets-v11',
+    zoomOffset: -1,
     accessToken: 'pk.eyJ1IjoidGVycmFwZXV0ZXMiLCJhIjoiY2p0N3IxZjRhMDB5bDQ1cW52Z2s2MnVnNCJ9.Ism1OhdYA3qPFom2htkx8w'
-  }).addTo(map)
-  return map
+  }).addTo(map);
+
+  return map;
 }

--- a/naturapeute/static/js/utils.js
+++ b/naturapeute/static/js/utils.js
@@ -1,24 +1,25 @@
-const SWITZERLAND_CENTER = [46.8182, 8.2275]; 
-const SWITZERLAND_BOUNDS = [[45.818, 5.000], [47.808, 10.000]]; 
-const DEFAULT_ZOOM = 8;
+const SWITZERLAND_CENTER = [46.8182, 8.2275]
+const SWITZERLAND_BOUNDS = [[45.818, 5.000], [47.808, 10.000]]
+const DEFAULT_ZOOM = 8
 
 function initMap(elem) {
     const map = L.map(elem, {
-    center: SWITZERLAND_CENTER,
-    zoom: DEFAULT_ZOOM,
-    maxBounds: SWITZERLAND_BOUNDS,
-    minZoom: 7,
-    maxZoom: 18
-  });
+        center: SWITZERLAND_CENTER,
+        zoom: DEFAULT_ZOOM,
+        maxBounds: SWITZERLAND_BOUNDS,
+        minZoom: 7,
+        maxZoom: 18
+    })
 
     L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
-    attribution: '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>',
-    tileSize: 512,
-    maxZoom: 18,
-    id: 'mapbox/streets-v11',
-    zoomOffset: -1,
-    accessToken: 'pk.eyJ1IjoidGVycmFwZXV0ZXMiLCJhIjoiY2p0N3IxZjRhMDB5bDQ1cW52Z2s2MnVnNCJ9.Ism1OhdYA3qPFom2htkx8w'
-  }).addTo(map);
+        attribution: '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>',
+        tileSize: 512,
+        maxZoom: 18,
+        id: 'mapbox/streets-v11',
+        zoomOffset: -1,
+        accessToken: 'pk.eyJ1IjoidGVycmFwZXV0ZXMiLCJhIjoiY2p0N3IxZjRhMDB5bDQ1cW52Z2s2MnVnNCJ9.Ism1OhdYA3qPFom2htkx8w'
+    }).addTo(map)
 
-  return map;
+    return map
 }
+

--- a/naturapeute/templates/therapists.html
+++ b/naturapeute/templates/therapists.html
@@ -226,8 +226,15 @@
     return marker
   })
   const markersGroup = L.featureGroup(markers)
-  map.fitBounds(markersGroup.getBounds())
   markersGroup.addTo(map)
+
+  if (markers.length > 0) {
+  const bounds = markersGroup.getBounds();
+  map.fitBounds(bounds, {
+    padding: [50, 50],
+    maxZoom: 12  // Limita lo zoom massimo quando si fa il fit
+  });
+}
 </script>
 {% endif %}
 

--- a/naturapeute/templates/therapists.html
+++ b/naturapeute/templates/therapists.html
@@ -229,11 +229,11 @@
   markersGroup.addTo(map)
 
   if (markers.length > 0) {
-  const bounds = markersGroup.getBounds();
+  const bounds = markersGroup.getBounds()
   map.fitBounds(bounds, {
     padding: [50, 50],
     maxZoom: 12  // Limita lo zoom massimo quando si fa il fit
-  });
+  })
 }
 </script>
 {% endif %}


### PR DESCRIPTION
**Map Improvements for Swiss Therapists**

This PR introduces improvements to the therapist map to ensure better visualization and user experience in Switzerland.
Changes Overview

_utils.js Modifications_

```javascript
const SWITZERLAND_CENTER = [46.8182, 8.2275]
const SWITZERLAND_BOUNDS = [[45.818, 5.000], [47.808, 10.000]]
const DEFAULT_ZOOM = 8

function initMap(elem) {
    const map = L.map(elem, {
        center: SWITZERLAND_CENTER,
        zoom: DEFAULT_ZOOM,
        maxBounds: SWITZERLAND_BOUNDS,
        minZoom: 7, 
```

The initMap function has been refactored to ensure the map stays centered on Switzerland:

Replaced dynamic latlng and zoom parameters with fixed values for Switzerland
Added maxBounds to restrict navigation to the Swiss area
Implemented minZoom to prevent excessive zooming out

_therapists.html Improvements_

```javascript
const markersGroup = L.featureGroup(markers)
  markersGroup.addTo(map)

  if (markers.length > 0) {
  const bounds = markersGroup.getBounds()
  map.fitBounds(bounds, {
    padding: [50, 50],
    maxZoom: 12  // 
  })
}```


Marker management has been optimized with the following changes:

Removed automatic fitBounds that could decenter the map
Added conditional view adaptation only when markers are present
Limited zoom level when adapting to markers
Added padding for better visualization

Benefits
These modifications ensure:

The map consistently opens centered on Switzerland
Users cannot navigate too far beyond Swiss borders
View adapts to markers while maintaining a reasonable scale
User experience remains consistent regardless of therapist locations

Technical Details
The main goal was to improve the map's usability while maintaining focus on the Swiss region. This was achieved by implementing fixed geographical constraints and optimizing marker visualization.
Previous PR
This is an updated version of a previous PR, with semicolons removed as requested to maintain code consistency.