### PR TITLE
update privacy and policy links - footer

### DIFF
--- a/naturapeute/templates/base.html
+++ b/naturapeute/templates/base.html
@@ -44,8 +44,8 @@
         <a href="/journal/salons-et-evenements-autour-des-therapies-complementaires" title="Salons et rencontres autour des thérapies">Salons et rencontres</a>
         <a href="https://pro.naturapeute.ch" target="_blank" title="Réseau thérapeutes en Suisse">Espace Thérapeute</a>
         <a href="/charte.html">Charte</a>
-        <a href="/policy.html">Conditions d'utilisation</a>
-        <a href="/privacy.html">Confidentialité</a>
+        <a href="https://pro.naturapeute.ch/policy.html">Conditions d'utilisation</a>
+        <a href="https://pro.naturapeute.ch/privacy.html">Confidentialité</a>
         <a href="/navigation.html">Navigation</a>
         <a href="mailto:contact@naturapeute.ch">Nous contacter</a>
       </div>


### PR DESCRIPTION
The footer link "Conditions d'utilisations" points to "https://pro.naturapeute.ch/policy.html" now.
The footer link  "Confidentialité" points to "https://pro.naturapeute.ch/privacy.html".