### PR TITLE
Calendly feature

### DIFF
--- a/naturapeute/migrations/0029_therapist_calendly_url.py
+++ b/naturapeute/migrations/0029_therapist_calendly_url.py
@@ -1,0 +1,12 @@
+from django.db import migrations, models
+class Migration(migrations.Migration):
+    dependencies = [
+        ('naturapeute', '0028_alter_therapist_languages'),
+    ]
+    operations = [
+        migrations.AddField(
+            model_name='therapist',
+            name='calendly_url',
+            field=models.URLField(blank=True, help_text='URL Calendly du thérapeute', max_length=255, null=True),
+        ),
+    ]

--- a/naturapeute/models.py
+++ b/naturapeute/models.py
@@ -193,8 +193,9 @@ class Therapist(models.Model):
     symptoms = models.ManyToManyField(Symptom, related_name="therapists", blank=True)
     membership = models.CharField(max_length=20, choices=MEMBERSHIPS)
     patients = models.ManyToManyField("Patient", through="TherapistPatient", related_name="therapists")
-    invoice_data = models.JSONField(default=invoice_data, null=True, blank=True)
+    invoice_data = models.JSONField(default=dict, null=True, blank=True)
     services = ArrayField(models.IntegerField(), null=True, blank=True)
+    calendly_url = models.URLField(max_length=255, null=True, blank=True, help_text="URL Calendly du thérapeute")
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
 

--- a/naturapeute/templates/therapist.html
+++ b/naturapeute/templates/therapist.html
@@ -90,9 +90,20 @@
       <li><i class="fa fa-envelope"></i> <a href="mailto:{{ therapist.email }}" title="Contacter {{therapist}} par email">Envoyer un email</a></li>
     </ul>
     <button class=primary id=contactButton><i class="fa fa-phone fa-flip-horizontal"> </i> Contacter</button>
+    {% if therapist.calendly_url %}
+    <button class="primary" id="reserveButton"><i class="fa fa-calendar"></i> Réserver</button>
+    {% endif %}
     <!-- <a class=button href={{ request.path }}vcf><i class="far fa-address-card"></i> Télécharger la vCard</a> -->
   </aside>
 </article>
+
+<!-- Modal Calendly -->
+<div id="calendlyModal" class="modal">
+  <div class="modal-content">
+    <span class="close">&times;</span>
+    <div id="calendlyWidget"></div>
+  </div>
+</div>
 
 <style>
   article {
@@ -173,6 +184,54 @@
     margin-top: 1rem;
     width: 100%;
   }
+
+  /* Modal styles */
+  .modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.4);
+  }
+
+  .modal-content {
+    background-color: #fefefe;
+    margin: 5% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
+    max-width: 900px;
+    height: 80vh;
+    position: relative;
+  }
+
+  .close {
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+  }
+
+  .close:hover,
+  .close:focus {
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  #calendlyWidget {
+    height: calc(100% - 40px);
+    margin-top: 20px;
+  }
+
+  #reserveButton {
+    margin-top: 1rem;
+  }
 </style>
 
 {# After CSS for map sizing reasons #}
@@ -187,5 +246,33 @@
       document.querySelector('#contactInfos').classList.remove('hidden')
     })
   })
+
+  {% if therapist.calendly_url %}
+  // Calendly integration
+  const modal = document.getElementById("calendlyModal");
+  const btn = document.getElementById("reserveButton");
+  const span = document.getElementsByClassName("close")[0];
+  
+  btn.onclick = function() {
+    modal.style.display = "block";
+    Calendly.initInlineWidget({
+      url: '{{ therapist.calendly_url }}',
+      parentElement: document.getElementById('calendlyWidget'),
+    });
+  }
+  
+  span.onclick = function() {
+    modal.style.display = "none";
+  }
+  
+  window.onclick = function(event) {
+    if (event.target == modal) {
+      modal.style.display = "none";
+    }
+  }
+  {% endif %}
 </script>
+
+<!-- Calendly inline widget -->
+<script src="https://assets.calendly.com/assets/external/widget.js" async></script>
 {% endblock %}


### PR DESCRIPTION
# Calendly Integration for Therapists

This pull request adds Calendly integration to allow therapists to display their booking availability directly on their profile pages.

## Changes

- Added `calendly_url` field to the Therapist model
- Created migration to update the database schema
- Updated therapist template to display the Calendly booking widget

## Note about this PR

I've created this new pull request to replace PR #9  and PR#8 which had migration issues. The previous PR contained inconsistent migration files that caused conflicts. 
